### PR TITLE
Support for getting only whitelisted dimensions of the image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ integration_run integration int:
 	@pytest -sv integration_tests/ -p no:tldr
 
 pint pintegration:
-	@pytest -sv integration_tests/ -p no:tldr -n `nproc`
+	@pytest -sv integration_tests/ -p no:tldr -n 4
 
 coverage:
 	@coverage report -m --fail-under=10
 
 unit:
-	@pytest -n `nproc` --cov=thumbor tests/
+	@pytest -n 4 --cov=thumbor tests/
 
 kill_redis:
 	@-redis-cli -p 6668 -a hey_you shutdown

--- a/tests/handler_lists/test_whitelist_dimensions_handler_list.py
+++ b/tests/handler_lists/test_whitelist_dimensions_handler_list.py
@@ -1,0 +1,39 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from preggy import expect
+
+import thumbor.handler_lists.whitelist_dimensions as handler_list
+from thumbor.handlers.whitelist_dimensions import WhitelistDimensionsHandler
+from thumbor.testing import TestCase
+
+
+class WhitelistDimensionsHandlerListTestCase(TestCase):
+    def test_can_get_handlers(self):
+        ctx = self.get_context()
+        ctx.config.USE_DIMENSIONS_WHITELIST = True
+
+        handlers = handler_list.get_handlers(ctx)
+
+        expect(handlers).not_to_be_null()
+        expect(handlers).to_length(1)
+        url, handler, initializer = handlers[0]
+        expect(url).to_equal(r"/whitelist_dimensions/?")
+        expect(handler).to_equal(WhitelistDimensionsHandler)
+        expect(initializer).to_equal({"context": ctx})
+
+    def test_can_disable_whitelist_dimensions(self):
+        ctx = self.get_context()
+        ctx.config.USE_DIMENSIONS_WHITELIST = False
+
+        handlers = handler_list.get_handlers(ctx)
+
+        expect(handlers).not_to_be_null()
+        expect(handlers).to_be_empty()

--- a/tests/handlers/test_whitelist_dimensions.py
+++ b/tests/handlers/test_whitelist_dimensions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+import tempfile
+from os.path import abspath, dirname, join
+
+from preggy import expect
+from tornado.testing import gen_test
+from tests.base import TestCase
+from thumbor.config import Config
+from thumbor.context import Context
+from thumbor.importer import Importer
+
+
+class WhitelistDimensionsHandlerTestCase(TestCase):
+    def get_context(self):
+        file_storage_root_path = tempfile.TemporaryDirectory().name
+        cfg = Config()
+        cfg.USE_DIMENSIONS_WHITELIST = True
+        cfg.LOADER = "thumbor.loaders.file_loader"
+        cfg.FILE_LOADER_ROOT_PATH = abspath(
+            join(dirname(__file__), "../fixtures/images/")
+        )
+        cfg.STORAGE = "thumbor.storages.file_storage"
+        cfg.FILE_STORAGE_ROOT_PATH = file_storage_root_path
+        importer = Importer(cfg)
+        importer.import_modules()
+        return Context(None, cfg, importer)
+
+    @gen_test
+    async def test_can_get_whitelist_dimensions(self):
+        response = await self.async_fetch("/whitelist_dimensions")
+        expect(response.code).to_equal(200)
+        expect(response.body).to_equal("")
+
+    @gen_test
+    async def test_can_put_object_to_whitelist_dimensions(self):
+        response = await self.async_fetch(
+            "/whitelist_dimensions?20x30", method="PUT", body=""
+        )
+        expect(response.code).to_equal(200)
+        expect(response.body).to_equal("")
+
+    @gen_test
+    async def test_can_read_updated_whitelist(self):
+        await self.async_fetch("/whitelist_dimensions?100x200", method="PUT", body="")
+        response = await self.async_fetch("/whitelist_dimensions")
+        expect(response.code).to_equal(200)
+        expect(b"100x200\n" in response.body).to_equal(True)
+
+    @gen_test
+    async def test_can_only_get_whitelisted_dimensions_image(self):
+        # note the image.jpg is of size 300x400
+        response = await self.async_fetch("/unsafe/image.jpg")
+        expect(response.code).to_equal(200)
+        await self.async_fetch("/whitelist_dimensions?100x200", method="PUT", body="")
+
+        # original size ok
+        response = await self.async_fetch("/unsafe/image.jpg")
+        expect(response.code).to_equal(200)
+
+        response = await self.async_fetch("/unsafe/10x20/image.jpg")
+        expect(response.code).to_equal(400)
+
+        response = await self.async_fetch("/unsafe/10x/image.jpg")
+        expect(response.code).to_equal(400)
+
+        # whitelisted dimension ok
+        response = await self.async_fetch("/unsafe/100x200/image.jpg")
+        expect(response.code).to_equal(200)

--- a/thumbor/config.py
+++ b/thumbor/config.py
@@ -217,6 +217,13 @@ Config.define(
 )
 
 Config.define(
+    "USE_DIMENSIONS_WHITELIST",
+    False,
+    "Indicates whether thumbor should enable image dimension "
+    "functionality to prevent serving un-supported image dimensions",
+    "Imaging"
+)
+Config.define(
     "ENGINE_THREADPOOL_SIZE",
     0,
     "Size of the thread pool used for image transformations."

--- a/thumbor/handler_lists/__init__.py
+++ b/thumbor/handler_lists/__init__.py
@@ -14,6 +14,7 @@ BUILTIN_HANDLERS = [
     "thumbor.handler_lists.healthcheck",
     "thumbor.handler_lists.upload",
     "thumbor.handler_lists.blacklist",
+    "thumbor.handler_lists.whitelist_dimensions",
 ]
 
 HandlerList = _RuleList

--- a/thumbor/handler_lists/whitelist_dimensions.py
+++ b/thumbor/handler_lists/whitelist_dimensions.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from typing import Any, cast
+
+from thumbor.handler_lists import HandlerList
+from thumbor.handlers.whitelist_dimensions import WhitelistDimensionsHandler
+
+
+def get_handlers(context: Any) -> HandlerList:
+    is_whitelist_dimensions_enabled = cast(bool, context.config.USE_DIMENSIONS_WHITELIST)
+    if not is_whitelist_dimensions_enabled:
+        return []
+
+    return [(r"/whitelist_dimensions/?", WhitelistDimensionsHandler, {"context": context})]

--- a/thumbor/handlers/__init__.py
+++ b/thumbor/handlers/__init__.py
@@ -768,6 +768,48 @@ class BaseHandler(tornado.web.RequestHandler):
 
         return ""
 
+    def extract_whitelist_dimensions(self, blob):
+        """
+        Extracts the dimensions from the new-line separated into a list of (wxh) tuples
+
+        :param blob: The file contents, can be of the form
+        w1xh1
+        w2xh2
+        w3x
+        ....
+        :return: A list of tuples [(w1, h1), (w2, h2), (w3, h3)]
+        """
+
+        whitelisted_dimensions = []
+
+        if not blob:
+            return whitelisted_dimensions
+        lines = blob.split('\n')
+
+        for line in list(filter(lambda x: x, lines)):
+            line = line.strip().lower()
+            # filtering out the empty dimension
+            dimensions = list(filter(lambda d: d, line.split('x')))
+            if len(dimensions) > 2:
+                logger.warning("whitelist dimensions %s not in the form wxh ", line)
+                self._error(400, "Unsupported whitelist dimension  expected wxh, given %s" % line)
+                return
+            if len(dimensions) == 1:
+                w = h = dimensions[0]
+            else:
+                w, h = dimensions
+            whitelisted_dimensions.append((int(w), int(h)))
+        return whitelisted_dimensions
+
+    async def get_whitelist_dimensions_contents(self):
+        filename = "whitelist_dimensions.txt"
+
+        exists = await (self.context.modules.storage.exists(filename))
+        if exists:
+            whitelisted_dimensions = await (self.context.modules.storage.get(filename))
+            return whitelisted_dimensions.decode()
+        return ""
+
     async def acquire_url_lock(self, url):
         if url not in BaseHandler.url_locks:
             BaseHandler.url_locks[url] = Condition()

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -61,7 +61,21 @@ class ImagingHandler(ContextHandler):
                     % self.context.request.image_url,
                 )
                 return
-        raise Exception('sjain xxx exception - image handler')
+
+        if self.context.config.USE_DIMENSIONS_WHITELIST:
+            whitelisted_dimensions_content = await self.get_whitelist_dimensions_contents()
+            whitelisted_dimensions = self.extract_whitelist_dimensions(whitelisted_dimensions_content)
+
+            if whitelisted_dimensions:
+                w = self.context.request.width
+                h = self.context.request.height
+                is_orig_dimension = (w == 0 and h == 0)
+                if (w, h) not in whitelisted_dimensions and not is_orig_dimension:
+                    self._error(
+                        400,
+                        "Source image dimensions %sx%s is not whitelisted"
+                    )
+                    return
 
         url_signature = self.context.request.hash
         if url_signature:

--- a/thumbor/handlers/imaging.py
+++ b/thumbor/handlers/imaging.py
@@ -61,6 +61,7 @@ class ImagingHandler(ContextHandler):
                     % self.context.request.image_url,
                 )
                 return
+        raise Exception('sjain xxx exception - image handler')
 
         url_signature = self.context.request.hash
         if url_signature:

--- a/thumbor/handlers/whitelist_dimensions.py
+++ b/thumbor/handlers/whitelist_dimensions.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# thumbor imaging service
+# https://github.com/thumbor/thumbor/wiki
+
+# Licensed under the MIT license:
+# http://www.opensource.org/licenses/mit-license
+# Copyright (c) 2011 globo.com thumbor@googlegroups.com
+
+from thumbor.handlers import ContextHandler
+from thumbor.utils import logger
+
+
+class WhitelistDimensionsHandler(ContextHandler):
+    async def get(self):
+        whitelist_dimensions = await self.get_whitelist_dimensions_contents()
+
+        self.write(whitelist_dimensions)
+        self.set_header("Content-Type", "text/plain")
+        self.set_status(200)
+
+    async def put(self):
+        whitelist_dimensions = await self.get_whitelist_dimensions_contents()
+
+        whitelist_dimensions += self.request.query + "\n"
+        logger.debug("Adding to whitelist dimensions: %s", self.request.query)
+        await self.context.modules.storage.put("whitelist_dimensions.txt", whitelist_dimensions.encode())
+        self.set_status(200)


### PR DESCRIPTION
The intention of this PR is to provide support for a whitelist of dimensions that can be served as an opt-in setting.

The reason for this is that Thumbor can be used typically behind a CDN and it can serve a combination of a large set of images that can be cached in the CDN or otherwise cause traffic on the server which could be exploited with DoS attacks. 

The config `USE_DIMENSIONS_WHITELIST` can be set to `True` whereby anything in the file `whitelist_dimensions.txt` will be whitelisted. The content of the file will have `wxh` format with new line (pretty typical setup as the blacklist)
eg
```
20x
200x300
30x90
```

etc. Few things to note:

1. If the config `USE_DIMENSIONS_WHITELIST` is set to `True`, but the file `whitelist_dimensions.txt` doesn't have any content, the config will be considered as unset and will be ignored. This is purely a judgment call and can be discussed. Can a whitelist of null be considered a whitelist at all?

2. If the config `USE_DIMENSIONS_WHITELIST` is set to `True`, and the `whitelist_dimensions.txt`
has the content 
```
200x200
400x300
```
any request for the original size image will still be allowed.

**Tests**

2 test files have been written

```
(venv_thumbor) ➜  thumbor git:(addwhitelist) pytest tests/handler_lists/test_whitelist_dimensions_handler_list.py --show-capture=all                    [20/04/4| 9:04PM]
..
------------------------------------------------------------------------------
Ran 2 tests in 0.07s

OK
```

```
(venv_thumbor) ➜  thumbor git:(addwhitelist) pytest tests/handlers/test_whitelist_dimensions.py --verbose --show-capture=all                            [20/04/4| 9:04PM]
platform darwin -- Python 3.7.4
pytest==5.4.1
py==1.8.1
pluggy==0.13.1
rootdir: /Users/saurabhjain/work/thumbor
plugins: tldr-0.2.1, asyncio-0.10.0, xdist-1.31.0, forked-1.1.3, cov-2.8.1
cachedir: .pytest_cache

------------------------------------------------------------------------------
tests/handlers/test_whitelist_dimensions.py::WhitelistDimensionsHandlerTestCase::test_can_get_whitelist_dimensions ... ok
tests/handlers/test_whitelist_dimensions.py::WhitelistDimensionsHandlerTestCase::test_can_put_object_to_whitelist_dimensions ... ok
tests/handlers/test_whitelist_dimensions.py::WhitelistDimensionsHandlerTestCase::test_can_read_all_dimensions_if_no_whitelists ... ok
tests/handlers/test_whitelist_dimensions.py::WhitelistDimensionsHandlerTestCase::test_can_read_only_whitelisted_dimensions ... ok
tests/handlers/test_whitelist_dimensions.py::WhitelistDimensionsHandlerTestCase::test_can_read_original_size ... ok
tests/handlers/test_whitelist_dimensions.py::WhitelistDimensionsHandlerTestCase::test_can_read_updated_whitelist ... ok

------------------------------------------------------------------------------
Ran 6 tests in 0.18s

OK
```


There were a few existing failures on my system for master so wasn't sure how to fix those.

